### PR TITLE
BlockImportAuxiliaryData removed

### DIFF
--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -76,7 +76,7 @@ pub(crate) trait BuildImportQueue<
 	) -> sc_service::error::Result<DefaultImportQueue<Block>>;
 }
 
-pub(crate) trait StartConsensus<Block: BlockT, RuntimeApi, BI, BIAuxiliaryData>
+pub(crate) trait StartConsensus<Block: BlockT, RuntimeApi, BI>
 where
 	RuntimeApi: ConstructNodeRuntimeApi<Block, ParachainClient<Block, RuntimeApi>>,
 {
@@ -97,7 +97,6 @@ where
 		announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
 		backend: Arc<ParachainBackend<Block>>,
 		node_extra_args: NodeExtraArgs,
-		block_import_extra_return_value: BIAuxiliaryData,
 	) -> Result<(), sc_service::Error>;
 }
 
@@ -118,11 +117,10 @@ fn warn_if_slow_hardware(hwbench: &sc_sysinfo::HwBench) {
 
 pub(crate) trait InitBlockImport<Block: BlockT, RuntimeApi> {
 	type BlockImport: sc_consensus::BlockImport<Block> + Clone + Send + Sync;
-	type BlockImportAuxiliaryData;
 
 	fn init_block_import(
 		client: Arc<ParachainClient<Block, RuntimeApi>>,
-	) -> sc_service::error::Result<(Self::BlockImport, Self::BlockImportAuxiliaryData)>;
+	) -> sc_service::error::Result<Self::BlockImport>;
 }
 
 pub(crate) struct ClientBlockImport;
@@ -132,12 +130,11 @@ where
 	RuntimeApi: Send + ConstructNodeRuntimeApi<Block, ParachainClient<Block, RuntimeApi>>,
 {
 	type BlockImport = Arc<ParachainClient<Block, RuntimeApi>>;
-	type BlockImportAuxiliaryData = ();
 
 	fn init_block_import(
 		client: Arc<ParachainClient<Block, RuntimeApi>>,
-	) -> sc_service::error::Result<(Self::BlockImport, Self::BlockImportAuxiliaryData)> {
-		Ok((client.clone(), ()))
+	) -> sc_service::error::Result<Self::BlockImport> {
+		Ok(client.clone())
 	}
 }
 
@@ -208,7 +205,6 @@ pub(crate) trait BaseNodeSpec {
 			Self::Block,
 			Self::RuntimeApi,
 			<Self::InitBlockImport as InitBlockImport<Self::Block, Self::RuntimeApi>>::BlockImport,
-			<Self::InitBlockImport as InitBlockImport<Self::Block, Self::RuntimeApi>>::BlockImportAuxiliaryData
 		>
 	>{
 		let telemetry = config
@@ -262,8 +258,7 @@ pub(crate) trait BaseNodeSpec {
 			.build(),
 		);
 
-		let (block_import, block_import_auxiliary_data) =
-			Self::InitBlockImport::init_block_import(client.clone())?;
+		let block_import = Self::InitBlockImport::init_block_import(client.clone())?;
 
 		let block_import = ParachainBlockImport::new(block_import, backend.clone());
 
@@ -283,7 +278,7 @@ pub(crate) trait BaseNodeSpec {
 			task_manager,
 			transaction_pool,
 			select_chain: (),
-			other: (block_import, telemetry, telemetry_worker_handle, block_import_auxiliary_data),
+			other: (block_import, telemetry, telemetry_worker_handle),
 		})
 	}
 }
@@ -300,7 +295,6 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 		Self::Block,
 		Self::RuntimeApi,
 		<Self::InitBlockImport as InitBlockImport<Self::Block, Self::RuntimeApi>>::BlockImport,
-		<Self::InitBlockImport as InitBlockImport<Self::Block, Self::RuntimeApi>>::BlockImportAuxiliaryData,
 	>;
 
 	const SYBIL_RESISTANCE: CollatorSybilResistance;
@@ -331,8 +325,7 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 			let parachain_fork_id = parachain_config.chain_spec.fork_id().map(ToString::to_string);
 			let advertise_non_global_ips = parachain_config.network.allow_non_globals_in_dht;
 			let params = Self::new_partial(&parachain_config)?;
-			let (block_import, mut telemetry, telemetry_worker_handle, block_import_auxiliary_data) =
-				params.other;
+			let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
 			let client = params.client.clone();
 			let backend = params.backend.clone();
 			let mut task_manager = params.task_manager;
@@ -558,7 +551,6 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 					announce_block,
 					backend.clone(),
 					node_extra_args,
-					block_import_auxiliary_data,
 				)?;
 			}
 

--- a/cumulus/polkadot-omni-node/lib/src/common/types.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/types.rs
@@ -49,7 +49,7 @@ pub type ParachainBlockImport<Block, BI> =
 	TParachainBlockImport<Block, BI, ParachainBackend<Block>>;
 
 /// Assembly of PartialComponents (enough to run chain ops subcommands)
-pub type ParachainService<Block, RuntimeApi, BI, BIExtraReturnValue> = PartialComponents<
+pub type ParachainService<Block, RuntimeApi, BI> = PartialComponents<
 	ParachainClient<Block, RuntimeApi>,
 	ParachainBackend<Block>,
 	(),
@@ -59,6 +59,5 @@ pub type ParachainService<Block, RuntimeApi, BI, BIExtraReturnValue> = PartialCo
 		ParachainBlockImport<Block, BI>,
 		Option<Telemetry>,
 		Option<TelemetryWorkerHandle>,
-		BIExtraReturnValue,
 	),
 >;

--- a/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
+++ b/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
@@ -201,7 +201,6 @@ where
 			Block,
 			RuntimeApi,
 			InitBlockImport::BlockImport,
-			InitBlockImport::BlockImportAuxiliaryData,
 		> + 'static,
 	InitBlockImport: self::InitBlockImport<Block, RuntimeApi> + Send + 'static,
 	InitBlockImport::BlockImport:
@@ -223,7 +222,7 @@ where
 			keystore_container,
 			select_chain: _,
 			transaction_pool,
-			other: (_, mut telemetry, _, _),
+			other: (_, mut telemetry, _),
 		} = Self::new_partial(&config)?;
 
 		// Since this is a dev node, prevent it from connecting to peers.
@@ -546,7 +545,6 @@ impl<Block: BlockT<Hash = DbHash>, RuntimeApi, AuraId>
 			ParachainClient<Block, RuntimeApi>,
 			<AuraId::BoundedPair as Pair>::Public,
 		>,
-		(),
 	> for StartSlotBasedAuraConsensus<Block, RuntimeApi, AuraId>
 where
 	RuntimeApi: ConstructNodeRuntimeApi<Block, ParachainClient<Block, RuntimeApi>>,
@@ -579,7 +577,6 @@ where
 		announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
 		backend: Arc<ParachainBackend<Block>>,
 		node_extra_args: NodeExtraArgs,
-		_: (),
 	) -> Result<(), Error> {
 		let proposer = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),
@@ -642,12 +639,11 @@ where
 		ParachainClient<Block, RuntimeApi>,
 		<AuraId::BoundedPair as Pair>::Public,
 	>;
-	type BlockImportAuxiliaryData = ();
 
 	fn init_block_import(
 		client: Arc<ParachainClient<Block, RuntimeApi>>,
-	) -> sc_service::error::Result<(Self::BlockImport, Self::BlockImportAuxiliaryData)> {
-		Ok((SlotBasedBlockImport::new(client.clone(), client), ()))
+	) -> sc_service::error::Result<Self::BlockImport> {
+		Ok(SlotBasedBlockImport::new(client.clone(), client))
 	}
 }
 
@@ -680,7 +676,7 @@ pub(crate) struct StartLookaheadAuraConsensus<Block, RuntimeApi, AuraId>(
 );
 
 impl<Block: BlockT<Hash = DbHash>, RuntimeApi, AuraId>
-	StartConsensus<Block, RuntimeApi, Arc<ParachainClient<Block, RuntimeApi>>, ()>
+	StartConsensus<Block, RuntimeApi, Arc<ParachainClient<Block, RuntimeApi>>>
 	for StartLookaheadAuraConsensus<Block, RuntimeApi, AuraId>
 where
 	RuntimeApi: ConstructNodeRuntimeApi<Block, ParachainClient<Block, RuntimeApi>>,
@@ -705,7 +701,6 @@ where
 		announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
 		backend: Arc<ParachainBackend<Block>>,
 		node_extra_args: NodeExtraArgs,
-		_: (),
 	) -> Result<(), Error> {
 		let proposer = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),


### PR DESCRIPTION
  1. spec.rs - Trait definitions and usage

  - Removed BlockImportAuxiliaryData associated type from InitBlockImport trait (spec.rs:119-125)
  - Changed return type from tuple to single value in init_block_import()
  - Removed BIAuxiliaryData generic parameter from StartConsensus trait (spec.rs:79-101)
  - Removed block_import_extra_return_value parameter from start_consensus() method
  - Updated ClientBlockImport implementation to return single value instead of tuple (spec.rs:128-139)
  - Updated BaseNodeSpec::new_partial() signature and implementation (spec.rs:201-282)
  - Updated NodeSpec trait bound to remove auxiliary data type (spec.rs:294-298)
  - Updated start_node() to remove auxiliary data extraction and passing (spec.rs:328, 537-554)

  2. aura.rs - Trait implementations

  - Updated AuraNode NodeSpec implementation to remove auxiliary data from generic bounds (aura.rs:200-204)
  - Removed 4th generic parameter from StartSlotBasedAuraConsensus implementation (aura.rs:539-548)
  - Removed unused parameter from start_consensus() function (aura.rs:555-580)
  - Updated InitBlockImport implementation to return single value (aura.rs:629-648)
  - Removed 4th generic parameter from StartLookaheadAuraConsensus implementation (aura.rs:680-681)
  - Removed unused parameter from start_consensus() function (aura.rs:688-705)
  - Fixed dev node destructuring to match new tuple size (aura.rs:225)

  3. types.rs - Type alias

  - Removed BIExtraReturnValue generic parameter from ParachainService type alias (types.rs:52-63)
  - Removed BIExtraReturnValue from the tuple in the other field

  Verification Results

  ✅ cargo check --release -p polkadot-omni-node-lib - Passed
  ✅ cargo build --release -p polkadot-omni-node - Completed successfully

  The refactoring successfully removed the unused BlockImportAuxiliaryData parameter throughout the codebase, simplifying the trait signatures and reducing generic parameter complexity by 1 across multiple traits.